### PR TITLE
Prevent sync fluid loads

### DIFF
--- a/src/main/java/me/wesley1808/servercore/mixin/optimizations/sync_loads/EntityMixin.java
+++ b/src/main/java/me/wesley1808/servercore/mixin/optimizations/sync_loads/EntityMixin.java
@@ -1,0 +1,38 @@
+package me.wesley1808.servercore.mixin.optimizations.sync_loads;
+
+import me.wesley1808.servercore.common.utils.ChunkManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+    @Shadow
+    public abstract double getEyeY();
+
+    @Shadow
+    public Level level;
+
+    @Shadow
+    public abstract double getX();
+
+    @Shadow
+    public abstract double getZ();
+
+    @Inject(
+            method = {"updateFluidOnEyes"},
+            at = {@At("HEAD")},
+            cancellable = true
+    )
+    private void servercore$onlyUpdateFluidIfLoaded(CallbackInfo ci) {
+        BlockPos blockPos = new BlockPos(this.getX(), this.getEyeY(), this.getZ());
+        if (!ChunkManager.isChunkLoaded(this.level, blockPos)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/servercore.mixins.json
+++ b/src/main/resources/servercore.mixins.json
@@ -59,6 +59,7 @@
     "optimizations.sync_loads.BeeMixin",
     "optimizations.sync_loads.BlockGetterMixin",
     "optimizations.sync_loads.DynamicGameEventListenerMixin",
+    "optimizations.sync_loads.EntityMixin",
     "optimizations.sync_loads.GroundPathNavigationMixin",
     "optimizations.sync_loads.MapItemMixin",
     "optimizations.sync_loads.RemoveBlockGoalMixin",


### PR DESCRIPTION
Hello! I added a new Mixin that prevents sync loads of chunks when an entity ticks (checking if its inside a fluid). This is specially useful when a player joins a world, because it starts ticking immediately and causes cascading lag. We tested this patch on a production server for a few months, and it successfully works as intended, decreasing lag without causing further issues.

I found the need for this Mixin using a profiler, this accounts for a large usage of the server tick time.