### PR TITLE
Ported Item Validation from PaperMC

### DIFF
--- a/src/main/java/me/wesley1808/servercore/common/config/Config.java
+++ b/src/main/java/me/wesley1808/servercore/common/config/Config.java
@@ -18,7 +18,8 @@ public final class Config {
             new Table(EntityLimitConfig.class, "entity_limits", "Stops animals / villagers from breeding if there are too many of the same type nearby."),
             new Table(OptimizationConfig.class, "optimizations", "Allows you to toggle specific optimizations that don't have full vanilla parity.\n These settings will only take effect after server restarts."),
             new Table(CommandConfig.class, "commands", "Allows you to disable specific commands and modify the way some of them are formatted."),
-            new Table(ActivationRangeConfig.class, "activation_range", "Stops entities from ticking if they are too far away.")
+            new Table(ActivationRangeConfig.class, "activation_range", "Stops entities from ticking if they are too far away."),
+            new Table(ItemValidationConfig.class, "item_validation", "Validates the size of items like books and disallows them from being sent to the client if they are too large."),
     };
 
     private static final Path CONFIG_PATH = FabricLoader.getInstance().getConfigDir().resolve("servercore.toml");

--- a/src/main/java/me/wesley1808/servercore/common/config/tables/ItemValidationConfig.java
+++ b/src/main/java/me/wesley1808/servercore/common/config/tables/ItemValidationConfig.java
@@ -1,0 +1,14 @@
+package me.wesley1808.servercore.common.config.tables;
+
+import me.wesley1808.servercore.common.config.ConfigEntry;
+
+public class ItemValidationConfig {
+    public static final ConfigEntry<Integer> MAX_BOOK_PAGE_SIZE = new ConfigEntry<>(2560, "The max number " +
+            "of bytes a single page in a book can contribute to the allowed byte total for a book.");
+
+    public static final ConfigEntry<Double> BOOK_TOTAL_MULTIPLIER = new ConfigEntry<>(0.98D, "Each page has this multiple of bytes from the last page" +
+            " as its contribution to the allowed byte total for a book (with the first page being having a multiplier of 1.0)");
+
+    public static final ConfigEntry<Integer> MAX_SIGN_LINE_LENGTH = new ConfigEntry<>(80, "The max number" +
+            " of characters a single line in a sign can contain.");
+}

--- a/src/main/java/me/wesley1808/servercore/mixin/validation/ServerEditBookMixin.java
+++ b/src/main/java/me/wesley1808/servercore/mixin/validation/ServerEditBookMixin.java
@@ -1,0 +1,87 @@
+package me.wesley1808.servercore.mixin.validation;
+
+import me.wesley1808.servercore.common.config.tables.ItemValidationConfig;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ServerboundEditBookPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * From: PaperMC (Book-Size-Limits.patch)
+ * License: GPL-3.0 (licenses/GPL.md)
+ */
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class ServerEditBookMixin {
+    @Shadow
+    @Final
+    static Logger LOGGER;
+
+    @Shadow
+    public ServerPlayer player;
+
+    @Shadow
+    @Final
+    private MinecraftServer server;
+
+    @Shadow
+    public abstract void disconnect(Component component);
+
+    @Inject(method = "handleEditBook", at = @At(value = "HEAD"), cancellable = true)
+    private void servercore$handleEditBook(ServerboundEditBookPacket packet, CallbackInfo ci) {
+        if (this.server.isSameThread()) {
+            return;
+        }
+
+        List<String> pageList = packet.getPages();
+        long byteTotal = 0;
+        int maxBookPageSize = ItemValidationConfig.MAX_BOOK_PAGE_SIZE.get();
+        double multiplier = Math.max(0.3D, Math.min(1D, ItemValidationConfig.BOOK_TOTAL_MULTIPLIER.get()));
+        long byteAllowed = maxBookPageSize;
+
+        for (String testString : pageList) {
+            int byteLength = testString.getBytes(StandardCharsets.UTF_8).length;
+            if (byteLength > 256 * 4) {
+                LOGGER.warn(this.player.getScoreboardName() + " tried to send a book with with a page too large!");
+                this.disconnect(Component.literal("Book too large!"));
+                ci.cancel();
+                return;
+            }
+
+            byteTotal += byteLength;
+            int length = testString.length();
+            int multibytes = 0;
+            if (byteLength != length) {
+                for (char c : testString.toCharArray()) {
+                    if (c > 127) {
+                        multibytes++;
+                    }
+                }
+            }
+
+            byteAllowed += (maxBookPageSize * Math.min(1, Math.max(0.1D, (double) length / 255D))) * multiplier;
+
+            if (multibytes > 1) {
+                // penalize MB
+                byteAllowed -= multibytes;
+            }
+        }
+
+        if (byteTotal > byteAllowed) {
+            LOGGER.warn("{} tried to send too large of a book. Book Size: {} - Allowed:  {} - Pages: {}", this.player.getScoreboardName(), byteTotal, byteAllowed, pageList.size());
+            this.disconnect(Component.literal("Book too large!"));
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/me/wesley1808/servercore/mixin/validation/ServerSignEditMixin.java
+++ b/src/main/java/me/wesley1808/servercore/mixin/validation/ServerSignEditMixin.java
@@ -1,0 +1,58 @@
+package me.wesley1808.servercore.mixin.validation;
+
+import me.wesley1808.servercore.common.config.tables.ItemValidationConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.protocol.game.ServerboundEditBookPacket;
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.FilteredText;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * From: PaperMC (Limit-Client-Sign-length-more.patch)
+ * License: GPL-3.0 (licenses/GPL.md)
+ */
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class ServerSignEditMixin {
+    @Shadow protected abstract CompletableFuture<List<FilteredText>> filterTextPacket(List<String> list);
+
+    @Shadow protected abstract void updateSignText(ServerboundSignUpdatePacket serverboundSignUpdatePacket, List<FilteredText> list);
+
+    @Shadow @Final private MinecraftServer server;
+
+    /**
+     * @author Celeste Peláez
+     * @reason Prevent signs from being too long
+     */
+    @Overwrite
+    public void handleSignUpdate(ServerboundSignUpdatePacket packet) {
+        int maxSignLineLength = ItemValidationConfig.MAX_SIGN_LINE_LENGTH.get();
+        String[] lines = packet.getLines();
+
+        for (int i = 0; i < lines.length; ++i) {
+            if (maxSignLineLength > 0 && lines[i].length() > maxSignLineLength) {
+                // This handles multibyte characters as 1
+                int offset = lines[i].codePoints().limit(maxSignLineLength).map(Character::charCount).sum();
+                if (offset < lines[i].length()) {
+                    lines[i] = lines[i].substring(0, offset); // this will break any filtering, but filtering is NYI as of 1.17
+                }
+            }
+        }
+
+        List<String> list = Stream.of(lines).map(ChatFormatting::stripFormatting).toList();
+        this.filterTextPacket(list).thenAcceptAsync(updatedList -> this.updateSignText(packet, updatedList), this.server);
+    }
+}

--- a/src/main/resources/servercore.mixins.json
+++ b/src/main/resources/servercore.mixins.json
@@ -66,7 +66,9 @@
     "optimizations.ticking.EntityCallbacksMixin",
     "optimizations.ticking.chunk.LevelChunkMixin",
     "optimizations.ticking.chunk.ServerChunkCacheMixin",
-    "optimizations.ticking.chunk.ServerLevelMixin"
+    "optimizations.ticking.chunk.ServerLevelMixin",
+    "validation.ServerEditBookMixin",
+    "validation.ServerSignEditMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Hello. I ported an small part of exploit protection from PaperMC. This PR adds a [patch](https://github.com/PaperMC/Paper/blob/master/patches/server/0289-Book-Size-Limits.patch) that prevents writing books that contain long characters like 􏿿, that when used, may [ban players from the chunk](https://minecraft.fandom.com/wiki/Tutorials/Chunk_ban). The other patch [prevents writing signs ](https://github.com/PaperMC/Paper/blob/master/patches/server/0299-Limit-Client-Sign-length-more.patch) by modified clients, because they can send more data than what will be displayed.