### PR TITLE
(Forge) Fixed mod conflict by using Jar-in-Jar. Fixes #74

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -33,11 +33,14 @@ dependencies {
     shadowCommon("com.electronwill.night-config:toml:${project.nightconfig}") { transitive false }
 
     // Mixin Extras
-    include(forgeRuntimeLibrary("com.github.llamalad7.mixinextras:mixinextras-forge:${project.mixin_extras}"))
+    forgeRuntimeLibrary"com.github.llamalad7.mixinextras:mixinextras-forge:${project.mixin_extras}"
 
     // Adventure Text
-    shadowCommon(implementation(forgeRuntimeLibrary("net.kyori:adventure-text-serializer-gson:${project.adventure_text}"))) { exclude group: "com.google.code.gson" }
-    shadowCommon(implementation(forgeRuntimeLibrary("net.kyori:adventure-text-minimessage:${project.adventure_text}")))
+    implementation "net.kyori:adventure-text-serializer-gson:${project.adventure_text}"
+    forgeRuntimeLibrary "net.kyori:adventure-text-serializer-gson:${project.adventure_text}"
+
+    implementation "net.kyori:adventure-text-minimessage:${project.adventure_text}"
+    forgeRuntimeLibrary "net.kyori:adventure-text-minimessage:${project.adventure_text}"
 
     // Allows running other mods in dev environment
     modLocalRuntime(fileTree(dir: 'runtime-mods', include: '*.jar'))


### PR DESCRIPTION
This fix was only applied to the Forge side as I don't have a way to test and compare it to the Fabric side as I don't use Fabric personally. This should resolve the mod conflicts I found and have tested to ensure both ServerCore, our custom mods, and Chunky are working as expected.