### PR TITLE
feat: add villager lobotomy whitelist tag

### DIFF
--- a/common/src/main/java/me/wesley1808/servercore/common/utils/EntityTags.java
+++ b/common/src/main/java/me/wesley1808/servercore/common/utils/EntityTags.java
@@ -1,0 +1,6 @@
+package me.wesley1808.servercore.common.utils;
+
+public class EntityTags {
+    public static final String EXCLUDE_FROM_ACTIVATION_RANGE = "exclude_ear";
+    public static final String EXCLUDE_FROM_LOBOTOMIZATION = "exclude_lobotomization";
+}

--- a/common/src/main/java/me/wesley1808/servercore/mixin/features/activation_range/EntityMixin.java
+++ b/common/src/main/java/me/wesley1808/servercore/mixin/features/activation_range/EntityMixin.java
@@ -4,6 +4,7 @@ import me.wesley1808.servercore.common.activation_range.ActivationRange;
 import me.wesley1808.servercore.common.activation_range.ActivationType;
 import me.wesley1808.servercore.common.interfaces.activation_range.ActivationEntity;
 import me.wesley1808.servercore.common.interfaces.activation_range.Inactive;
+import me.wesley1808.servercore.common.utils.EntityTags;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -90,12 +91,12 @@ public class EntityMixin implements Inactive, ActivationEntity {
     // ServerCore - Add a simple way to exclude certain entities from activation range.
     @Inject(method = "load", at = @At("RETURN"))
     private void servercore$onLoadNbt(CallbackInfo ci) {
-        this.servercore$excluded |= this.tags.contains("exclude_ear");
+        this.servercore$excluded |= this.tags.contains(EntityTags.EXCLUDE_FROM_ACTIVATION_RANGE);
     }
 
     @Inject(method = "addTag", at = @At("HEAD"))
     private void servercore$onTagAdded(String tag, CallbackInfoReturnable<Boolean> cir) {
-        this.servercore$excluded |= tag.equals("exclude_ear");
+        this.servercore$excluded |= tag.equals(EntityTags.EXCLUDE_FROM_ACTIVATION_RANGE);
     }
 
     @Override

--- a/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
+++ b/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
@@ -3,6 +3,7 @@ package me.wesley1808.servercore.mixin.features.ticking;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import me.wesley1808.servercore.common.config.tables.FeatureConfig;
 import me.wesley1808.servercore.common.utils.ChunkManager;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -17,6 +18,8 @@ import net.minecraft.world.level.chunk.ChunkAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Locale;
 
 /**
  * Based on: Purpur (Lobotomize-stuck-villagers.patch)
@@ -47,11 +50,15 @@ public abstract class VillagerMixin extends AbstractVillager {
     }
 
     @Unique
+    private boolean servercore$isLobotomyImmune() {
+        return this.getTags().contains("no_lobotomy");
+    }
+
     private boolean servercore$isLobotomized() {
         // Check half as often if not lobotomized for the last 3+ consecutive checks
         if (this.tickCount % (this.servercore$notLobotomizedCount > 3 ? 600 : 300) == 0) {
             // Offset Y for short blocks like dirt_path/farmland
-            this.servercore$lobotomized = this.isPassenger() || !this.servercore$canTravel(BlockPos.containing(this.getX(), this.getY() + 0.0625D, this.getZ()));
+            this.servercore$lobotomized = !servercore$isLobotomyImmune() && (this.isPassenger() || !this.servercore$canTravel(BlockPos.containing(this.getX(), this.getY() + 0.0625D, this.getZ())));
 
             if (this.servercore$lobotomized) {
                 this.servercore$notLobotomizedCount = 0;

--- a/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
+++ b/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
@@ -51,6 +51,7 @@ public abstract class VillagerMixin extends AbstractVillager {
         return this.getTags().contains("no_lobotomy");
     }
 
+    @Unique
     private boolean servercore$isLobotomized() {
         // Check half as often if not lobotomized for the last 3+ consecutive checks
         if (this.tickCount % (this.servercore$notLobotomizedCount > 3 ? 600 : 300) == 0) {

--- a/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
+++ b/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
@@ -3,7 +3,6 @@ package me.wesley1808.servercore.mixin.features.ticking;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import me.wesley1808.servercore.common.config.tables.FeatureConfig;
 import me.wesley1808.servercore.common.utils.ChunkManager;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -18,8 +17,6 @@ import net.minecraft.world.level.chunk.ChunkAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-
-import java.util.Locale;
 
 /**
  * Based on: Purpur (Lobotomize-stuck-villagers.patch)

--- a/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
+++ b/common/src/main/java/me/wesley1808/servercore/mixin/features/ticking/VillagerMixin.java
@@ -3,6 +3,7 @@ package me.wesley1808.servercore.mixin.features.ticking;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import me.wesley1808.servercore.common.config.tables.FeatureConfig;
 import me.wesley1808.servercore.common.utils.ChunkManager;
+import me.wesley1808.servercore.common.utils.EntityTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -47,16 +48,13 @@ public abstract class VillagerMixin extends AbstractVillager {
     }
 
     @Unique
-    private boolean servercore$isLobotomyImmune() {
-        return this.getTags().contains("no_lobotomy");
-    }
-
-    @Unique
     private boolean servercore$isLobotomized() {
         // Check half as often if not lobotomized for the last 3+ consecutive checks
         if (this.tickCount % (this.servercore$notLobotomizedCount > 3 ? 600 : 300) == 0) {
-            // Offset Y for short blocks like dirt_path/farmland
-            this.servercore$lobotomized = !servercore$isLobotomyImmune() && (this.isPassenger() || !this.servercore$canTravel(BlockPos.containing(this.getX(), this.getY() + 0.0625D, this.getZ())));
+
+            this.servercore$lobotomized = !this.getTags().contains(EntityTags.EXCLUDE_FROM_LOBOTOMIZATION) && (
+                    this.isPassenger() || !this.servercore$canTravel()
+            );
 
             if (this.servercore$lobotomized) {
                 this.servercore$notLobotomizedCount = 0;
@@ -69,7 +67,9 @@ public abstract class VillagerMixin extends AbstractVillager {
     }
 
     @Unique
-    private boolean servercore$canTravel(BlockPos center) {
+    private boolean servercore$canTravel() {
+        // Offset Y for short blocks like dirt_path/farmland
+        BlockPos center = BlockPos.containing(this.getX(), this.getY() + 0.0625D, this.getZ());
         ChunkAccess chunk = ChunkManager.getChunkNow(this.level(), center);
         if (chunk == null) {
             return false;


### PR DESCRIPTION
Allows a tag based override on whether a villager should be lobotomized, beneficial for farms that require villagers ticking in 1x1 containers, like a stacking raid farm